### PR TITLE
[FEAT] : 장애물 개수 조정

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -6,7 +6,7 @@ from maze import generate_maze, N, S, E, W
 from player import Player
 from renderer import draw_maze, draw_debuff_items, draw_debuff_hud
 from debuff import (
-    DebuffType, DebuffState, spawn_debuff_near_start,
+    DebuffType, DebuffState,DebuffItem, spawn_debuff_near_start,
     apply_debuff_on_pickup
 )
 
@@ -14,6 +14,7 @@ SLOW_DURATION_MS = 30_000       # 느려짐 30초
 REVERSE_DURATION_MS = 15_000    # 역방향 15초
 TIME_LEFT_MS = 30_000           # 제한 시간 30초 감소
 
+MAX_DEBUFF_ITEMS = 25
 
 def main():
     difficulty = select_difficulty()
@@ -52,41 +53,36 @@ def main():
 
     debuff_state = DebuffState()
     debuff_items = []
-    #    초반 긴장감을 위해 하나는 시작점 근처에 둡니다.
+    #    초반 긴장감을 위해 하나는 시작점 근처에 둠
     start_item = spawn_debuff_near_start(grid, width, height, rng, start=(0, 0))
     debuff_items.append(start_item)
 
-    # 2. 맵 전체에 랜덤하게 추가 배치
-    #    맵 크기에 비례해서 개수를 정합니다 (예: 전체 칸 수의 5% ~ 10%)
-    total_cells = width * height
-    target_item_count = int(total_cells * 0.05)  # 5% 비율 (조절 가능)
-    
-    # 이미 아이템이 있거나, 시작점/도착점인 위치 기록
+    # 2) 이미 사용된 위치 기록
     occupied_positions = set()
-    occupied_positions.add((0, 0))              # 시작점
-    occupied_positions.add((goal_x, goal_y))    # 도착점
-    occupied_positions.add((start_item.gx, start_item.gy)) # 첫 번째 아이템 위치
+    occupied_positions.add((0, 0))                           # 시작점
+    occupied_positions.add((goal_x, goal_y))                 # 도착점
+    occupied_positions.add((start_item.gx, start_item.gy))   # 첫 번째 아이템 위치
 
-    # 목표 개수가 될 때까지 랜덤 배치
-    # (이미 하나 넣었으니 target_item_count만큼 추가하거나, 합쳐서 count하거나 선택)
-    # 여기서는 '추가로' target_item_count 개를 더 뿌립니다.
+    # 3) 추가로 배치할 수 있는 최대 개수 계산
+    remaining_slots = MAX_DEBUFF_ITEMS - len(debuff_items)
+    if remaining_slots < 0:
+        remaining_slots = 0
+
+    # 4) 맵 크기 기반으로 후보 개수 계산 (그래도 너무 많지 않게 min 처리)
+    total_cells = width * height
+    percent_based = int(total_cells * 0.05)      # 원래 쓰던 5% 기준
+    target_item_count = min(remaining_slots, percent_based)
+
     current_added = 0
     while current_added < target_item_count:
         rx = rng.randint(0, width - 1)
         ry = rng.randint(0, height - 1)
 
-        # 이미 선점된 위치가 아니면 배치
         if (rx, ry) not in occupied_positions:
-            # 랜덤 타입 선택
             dtype = rng.choice([DebuffType.SLOW, DebuffType.TIME_LEFT, DebuffType.REVERSE])
-            
-            # 아이템 생성 (DebuffItem 클래스가 import 되어 있어야 함)
-            # 주의: debuff.py 파일에 DebuffItem 클래스가 정의되어 있다고 가정합니다.
-            from debuff import DebuffItem # 맨 위에 import 되어 있다면 생략 가능
-            
             new_item = DebuffItem(rx, ry, dtype)
             debuff_items.append(new_item)
-            
+
             occupied_positions.add((rx, ry))
             current_added += 1
 


### PR DESCRIPTION
###  Summary

-디버프 아이템이 맵 크기에 따라 과도하게 생성되는 문제를 해결했습니다.
-이제 디버프는 MAX_DEBUFF_ITEMS 값(기본 25) 을 기준으로 최대 개수만큼만 생성되며, 맵 크기 증가에 따라 20~40개 이상 생성되던 문제가 사라졌습니다.

### 변경 내용

-main.py 내 디버프 생성 로직 개선
-시작점 근처 1개 + 랜덤 배치 아이템 수를 MAX_DEBUFF_ITEMS 이하로 제한
-맵 크기 기반 비율(5%)과 비교하여 더 작은 값만 생성
-__pycache__, 보스 관련 파일 등 다른 변경사항은 포함하지 않음

###📌 관련 이슈

-#22 디버프 아이템 과도 생성 문제

✔ Checklist

 -main.py 외 다른 파일 변경 없음
 -브랜치 충돌 없음
 -MAX_DEBUFF_ITEMS 값 변경으로 손쉽게 개수 조절 가능
 -게임 밸런스 정상 동작 확인